### PR TITLE
fix(go_modules): fix undefined method `to_sym' for nil:NilClass

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -38,7 +38,7 @@ directory = ENV["DEPENDABOT_DIRECTORY"] || "/"
 
 # See lists of update strategies here:
 # https://github.com/wemake-services/kira-dependencies/issues/39
-update_strategy = ENV['DEPENDABOT_UPDATE_STRATEGY'].to_sym || nil
+update_strategy = ENV['DEPENDABOT_UPDATE_STRATEGY']&.to_sym || nil
 
 # Assignee to be set for this merge request.
 # Works best with marge-bot:


### PR DESCRIPTION
Fixes the following error when using `go_modules`:

```
./update.rb:41:in `<main>': undefined method `to_sym' for nil:NilClass (NoMethodError)
```
It was introduced after #39; please feel free to close this if you can provide a better solution.

Thanks