### PR TITLE
Allow passing custom credentials via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This configuration is best to be setup inside CI schedule's environment.
 - `DEPENDABOT_ASSIGNEE_GITLAB_ID` - (optional) Gitlab user id to assign to merge requests
 - `DEPENDABOT_GITLAB_APPROVE_MERGE` - (optional) setup to `true` if you want our bot to approve your merge requests
 - `DEPENDABOT_GITLAB_AUTO_MERGE` - (optional) setup to `true` if you want to auto merge this request
+- `DEPENDABOT_EXTRA_CREDENTIALS` - (optional) JSON of extra credential config, for example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)
 
 ### Per package manager
 

--- a/update.rb
+++ b/update.rb
@@ -4,6 +4,7 @@
 # It is intended to be used as a stop-gap until Dependabot's hosted instance
 # supports GitHub Enterprise and GitLab (coming soon!)
 
+require "json"
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"
 require "dependabot/update_checkers"
@@ -29,6 +30,12 @@ credentials << {
   # A GitLab access token with API permission
   "password" => ENV["KIRA_GITLAB_PERSONAL_TOKEN"]
 }
+
+json_credentials = ENV['DEPENDABOT_EXTRA_CREDENTIALS'] || ""
+unless json_credentials.to_s.strip.empty?
+  json_credentials = JSON.parse(json_credentials)
+  credentials.push(*json_credentials)
+end
 
 # Full name of the repo you want to create pull requests for.
 repo_name = ENV["DEPENDABOT_PROJECT_PATH"] # namespace/project


### PR DESCRIPTION
This PR would allow passing custom credentials to dependabot, which would in turn allow support for private registries.

For example, setting DEPENDABOT_EXTRA_CREDENTIALS in the gitlab runner schedule config to `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]` would allow auto-updating of FontAwesome Pro packages.

Please note that I did not test my script outside of making sure that the [credentials array could be extended this way](https://repl.it/repls/HeavenlyTechnologicalDistributeddatabase).