### PR TITLE
Fix API validation error when omitting assignee

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -160,7 +160,7 @@ dependencies.select(&:top_level?).each do |dep|
     files: updated_files,
     credentials: credentials,
     label_language: true,
-    assignees: [assignee]
+    assignees: [assignee].compact
   )
   pull_request = pr_creator.create
   puts " submitted"

--- a/update.rb
+++ b/update.rb
@@ -50,7 +50,9 @@ update_strategy = ENV['DEPENDABOT_UPDATE_STRATEGY']&.to_sym || nil
 # Assignee to be set for this merge request.
 # Works best with marge-bot:
 # https://github.com/smarkets/marge-bot
-assignee = ENV["DEPENDABOT_ASSIGNEE_GITLAB_ID"]
+assignees = [ENV["DEPENDABOT_ASSIGNEE_GITLAB_ID"]].compact
+assignees = nil if assignees.empty?
+
 package_manager = ENV["PACKAGE_MANAGER"] || "bundler"
 
 # Source branch for merge requests
@@ -160,7 +162,7 @@ dependencies.select(&:top_level?).each do |dep|
     files: updated_files,
     credentials: credentials,
     label_language: true,
-    assignees: [assignee].compact
+    assignees: assignees
   )
   pull_request = pr_creator.create
   puts " submitted"


### PR DESCRIPTION
Fixes API validation errors when creating MR without defining an assignee user (`DEPENDABOT_ASSIGNEE_GITLAB_ID`). Fixes #137.

This is happening because the Gitlab gem added support for creating MRs with multiple assignees to it (updated in #133). Previously, we were limited to creating MRs with only a single assignee. The Gitlab gem would take only the first user ID ([ref](https://github.com/dependabot/dependabot-core/commit/4fada2f6313979835eb5926573a159f3824c99a4#diff-093943eafda6737df7d787ecd1aca6eaL129)) instead of passing along the entire array of user IDs. Now it will pass along the entire array of user IDs.


The `DEPENDABOT_ASSIGNEE_GITLAB_ID` env var is passed along to the `Dependabot::PullRequestCreator.new` call in `update.rb` ([here](https://github.com/wemake-services/kira-dependencies/blob/master/update.rb#L156-L165)) as an array with the value from that env var. 

Omitting the `DEPENDABOT_ASSIGNEE_GITLAB_ID` env var causes the API validation error since the `assignee_ids` array becomes `[nil]` rather than `[]`. In the past this would just result in `assingee_id=null` rather than `assignee_ids=[null]` in the payload of the actual API call. The latter causing validation errors.
