### PR TITLE
Project default branch if no source_branch specified

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -56,7 +56,7 @@ assignees = nil if assignees.empty?
 package_manager = ENV["PACKAGE_MANAGER"] || "bundler"
 
 # Source branch for merge requests
-source_branch = ENV["DEPENDABOT_SOURCE_BRANCH"] || "master"
+source_branch = ENV["DEPENDABOT_SOURCE_BRANCH"] || nil
 
 source = Dependabot::Source.new(
   provider: "gitlab",


### PR DESCRIPTION
PR #117 replace the default to "master". Dependabot itself will find the default branch if nothing is specified.

Let dependabot-core find the default branch of the project seems better than defaulting to master branch. 