### PR TITLE
added an environment variable to exclude certain requirements to unlock versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ This configuration is best to be setup inside CI schedule's environment.
 ### Per package manager
 
 - `DEPENDABOT_UPDATE_STRATEGY` - (optional) change how each package manager updates your dependency versions, see list of allowed values [here](https://github.com/wemake-services/kira-dependencies/issues/39)
-- `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK` - (optional) exclude certain dependency updates requirements for each package manager, see list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow
+- `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK` - (optional) exclude certain dependency updates requirements for each package manager, see list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. Example: `own all` to only use the `none` version requirement

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ This configuration is best to be setup inside CI schedule's environment.
 ### Per package manager
 
 - `DEPENDABOT_UPDATE_STRATEGY` - (optional) change how each package manager updates your dependency versions, see list of allowed values [here](https://github.com/wemake-services/kira-dependencies/issues/39)
+- `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK` - (optional) exclude certain dependency updates requirements for each package manager, see list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow

--- a/update.rb
+++ b/update.rb
@@ -48,6 +48,10 @@ directory = ENV["DEPENDABOT_DIRECTORY"] || "/"
 # https://github.com/wemake-services/kira-dependencies/issues/39
 update_strategy = ENV['DEPENDABOT_UPDATE_STRATEGY']&.to_sym || nil
 
+# See description of requirements here:
+# https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
+excluded_requirements = ENV['DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK']&.split(" ")&.map(&:to_sym) || []
+
 # Assignee to be set for this merge request.
 # Works best with marge-bot:
 # https://github.com/smarkets/marge-bot
@@ -113,11 +117,11 @@ dependencies.select(&:top_level?).each do |dep|
 
   requirements_to_unlock =
     if !checker.requirements_unlocked_or_can_be?
-      if checker.can_update?(requirements_to_unlock: :none) then :none
+      if !excluded_requirements.include?(:none) && checker.can_update?(requirements_to_unlock: :none) then :none
       else :update_not_possible
       end
-    elsif checker.can_update?(requirements_to_unlock: :own) then :own
-    elsif checker.can_update?(requirements_to_unlock: :all) then :all
+    elsif !excluded_requirements.include?(:own) && checker.can_update?(requirements_to_unlock: :own) then :own
+    elsif !excluded_requirements.include?(:all) && checker.can_update?(requirements_to_unlock: :all) then :all
     else :update_not_possible
     end
 


### PR DESCRIPTION
We use `kira-dependencies` to update our projects dependencies and for one of our old rails projects with a lot of dependencies, the update script takes forever to run (timing out after 60 minutes and not even creating a single MR). I did some profiling and found that it was spending a significant portion (~65% of a single dependency runtime) of time running `checker.can_update?(requirements_to_unlock: :all)`. Since this is an old project with a complex gemfile, we would prefer that it only consider the faster `checker.can_update?(requirements_to_unlock: :own)` only so that the script can actually finish.

This PR adds an optional environment variable that teams like our can set to skip some requirement checks.