### PR TITLE
retry the job once if it fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@
   image: dependabot/dependabot-core
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
+  retry: 1
   before_script:
     - bundle install -j $(nproc) --path vendor
   script: bundle exec ruby ./update.rb


### PR DESCRIPTION
sometimes the docker job gets a timeout error. Seems like it would nice to retry the jobs once again if they fail, since most failures are likely to be transient (timeouts, rate limits, etc..).  