### PR TITLE
Add dependency dashboard

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -128,10 +128,10 @@ dependencies.select(&:top_level?).each do |dep|
       opened_merge_requests_for_this_dep = gitlab_client.merge_requests(
         repo_name,
         state: "opened",
-        search: "\"Bump #{dep.name}\"",
+        search: "Bump \" #{dep.name}\"",
         in: "title",
         with_merge_status_recheck: true
-      )
+      ).select { |mr| mr.title[/#{dep.name}(\s|,)/] }
       break unless opened_merge_requests_for_this_dep.map(&:merge_status).include?('checking')
     end
 


### PR DESCRIPTION
This creates an issue for each language that contains all the dependencies that need updates. It looks like this:

# Dependency Dashboard ruby

20 of 86 bundler dependencies are out of date.

name | current version | next version | merge request
-- | -- | -- | --
active_model_serializers | 0.10.11 | 0.10.12 | MR
aws-sdk-cloudfront | 1.43.0 | 1.46.0 | MR
aws-sdk-s3 | 1.84.1 | 1.86.1 | MR, MR


---

It also fixes a bug with finding open merge requests. That I found because the dashboard lists the merge requests that belong to the dependency. The search returns all MRs that have the dependency name in the title. So the dependency dashboard listed the MR for sidekiq-status gem as MR for sidekiq.