### PR TITLE
ignore versions via env variable DEPENDABOT_IGNORED_VERSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This configuration is best to be setup inside CI schedule's environment.
 - `DEPENDABOT_GITLAB_AUTO_MERGE` - (optional) setup to `true` if you want to auto merge this request
 - `DEPENDABOT_MAX_MERGE_REQUESTS` - (optional) setup the number of max openened merge requests you want.
 - `DEPENDABOT_EXTRA_CREDENTIALS` - (optional) JSON of extra credential config, for example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)
+- `DEPENDABOT_IGNORED_VERSIONS` - (optional) JSON of versions which should be ignored during update. The expected format is `{"vendor/package": [">0.1.0", ">0.2.0"]}`. It mirrors functionality of [`ignored_updates`](https://dependabot.com/docs/config-file/#ignored_updates) in dependabot.
 
 ### Per package manager
 

--- a/update.rb
+++ b/update.rb
@@ -38,6 +38,13 @@ unless json_credentials.to_s.strip.empty?
   credentials.push(*json_credentials)
 end
 
+# expected format is {"vendor/package": [">0.1.0", ">0.2.0"]}
+ignored_versions_json = ENV["DEPENDABOT_IGNORED_VERSIONS"] || ""
+ignored_versions = {}
+unless ignored_versions_json.to_s.strip.empty?
+  ignored_versions = JSON.parse(ignored_versions_json)
+end
+
 # Full name of the repo you want to create pull requests for.
 repo_name = ENV["DEPENDABOT_PROJECT_PATH"] # namespace/project
 
@@ -106,6 +113,7 @@ dependencies.select(&:top_level?).each do |dep|
   end
 
   begin
+
     #########################################
     # Get update details for the dependency #
     #########################################
@@ -113,7 +121,8 @@ dependencies.select(&:top_level?).each do |dep|
       dependency: dep,
       dependency_files: files,
       credentials: credentials,
-      requirements_update_strategy: update_strategy
+      requirements_update_strategy: update_strategy,
+      ignored_versions: ignored_versions[dep.name] || []
     )
 
     next if checker.up_to_date?


### PR DESCRIPTION
Environment variable format is following:

```json
{
  "vendor/packageA": [
    ">0.1.0",
    "<1.0.0"
  ],
  "vendor/packageB": [
    "^2.0.0"
  ]
}
```

By default there are no ignored versions

Closes #234 