### PR TITLE
Bump ruby version from 2.7.5 to 2.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby "2.7.5"
+ruby "2.7.6"
 source "https://rubygems.org"
 
 gem "dependabot-omnibus", "~> 0.196.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ DEPENDENCIES
   dependabot-omnibus (~> 0.196.3)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.2.20


### PR DESCRIPTION
The ruby version in the `dependabot/dependabot-core` Docker image has been updated to `2.7.6` (see https://github.com/dependabot/dependabot-core/commit/728148b2c5050ecca71f1ba6ff2593214ec1ace7).

This PR will fix the following error:
> Your Ruby version is 2.7.6, but your Gemfile specified 2.7.5