### PR TITLE
Get rid of bundler deprecation warning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,8 @@
     PACKAGE_MANAGER: $CI_JOB_NAME
   retry: 1
   before_script:
-    - bundle install -j $(nproc) --path vendor
+    - bundle config set --local path 'vendor'
+    - bundle install -j $(nproc)
   script: bundle exec ruby ./update.rb
   cache:
     paths:


### PR DESCRIPTION
`bundle install` outputs a warning that the `--path` flag is deprecated and will be no longer supported in a future release. It suggests to use `bundle config` instead.

```bash
$ bundle install -j $(nproc) --path vendor
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor'`, and stop using this flag
```