### PR TITLE
Remove ruby version pinning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-ruby "2.7.6"
 source "https://rubygems.org"
 
 gem "dependabot-omnibus", "~> 0.212.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,8 +156,5 @@ PLATFORMS
 DEPENDENCIES
   dependabot-omnibus (~> 0.212.0)
 
-RUBY VERSION
-   ruby 2.7.6p219
-
 BUNDLED WITH
    2.2.20


### PR DESCRIPTION
I see no point in that pin – it's there just to break things when ruby version in the dependabot is bumped :D

FYI, that pin was removed from original dependabot-script repo a while ago: https://github.com/dependabot/dependabot-script/commit/afe3d78bddf48b86b761ad18c0207fc6d35c29e1

Recently, dependabot switched to ruby v3 (https://github.com/dependabot/dependabot-core/commit/2badf4b2c1584dd1155c3c223240750135c7c388) so I had to remove the pin to fix it.