### PR TITLE
Update dependabot image location

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@
 # https://docs.gitlab.com/ee/ci/yaml/
 
 .dependabot:
-  image: dependabot/dependabot-core
+  image: ghcr.io/dependabot/dependabot-updater-$PACKAGE_MANAGER
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
   retry: 1


### PR DESCRIPTION
Use dependabot-updater hosted on GitHub Container Registry.

dependabot-core removed from docker hub because they migrated to github container registry and split large updater image to small images for each package manager ecosystem.